### PR TITLE
Always align canvas with Cytoscape canvases

### DIFF
--- a/src/cytoscape-canvas.js
+++ b/src/cytoscape-canvas.js
@@ -7,7 +7,7 @@
 
 		const cyCanvas = function(args) {
 			const cy = this;
-			const container = cy.container();
+			const container = cy.container().children[0];  // <div> element holding canvases
 
 			const canvas = document.createElement("canvas");
 

--- a/src/cytoscape-canvas.js
+++ b/src/cytoscape-canvas.js
@@ -46,7 +46,7 @@
 
 			canvas.setAttribute(
 				"style",
-				`position:absolute; top:0; left:0; z-index:${options.zIndex};`,
+				`position:absolute; z-index:${options.zIndex};`,
 			);
 
 			resize();


### PR DESCRIPTION
I found this was needed to get the canvas aligned under Cytoscape's canvases when using a `flex` HTML layout. So far I've been unable to produce a small example demonstrating the problem, but the following screen screenshots show what happens. The first one is the desired result; the second when things go wrong.

> ![screen shot 2018-11-22 at 12 39 50 pm](https://user-images.githubusercontent.com/239220/48873739-65f4b680-ee54-11e8-8759-e5250290482b.png)

> ![screen shot 2018-11-22 at 12 38 42 pm](https://user-images.githubusercontent.com/239220/48873749-77d65980-ee54-11e8-8767-54f400af937b.png)
